### PR TITLE
packages apt: add support for Debian 11 (bullseye)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,8 @@ jobs:
         label:
           - Debian GNU/Linux buster amd64
           - Debian GNU/Linux buster i386
+          - Debian GNU/Linux bullseye amd64
+          - Debian GNU/Linux bullseye arm64
           - CentOS 7
           - CentOS 8
           - AlmaLinux 8
@@ -31,6 +33,14 @@ jobs:
           - label: Debian GNU/Linux buster i386
             id: debian-buster-i386
             rake_arguments: apt:build APT_TARGETS=debian-buster-i386
+            repositories_path: packages/apt/repositories/
+          - label: Debian GNU/Linux bullseye amd64
+            id: debian-bullseye-amd64
+            rake_arguments: apt:build APT_TARGETS=debian-bullseye
+            repositories_path: packages/apt/repositories/
+          - label: Debian GNU/Linux bullseye arm64
+            id: debian-bullseye-arm64
+            rake_arguments: apt:build APT_TARGETS=debian-bullseye
             repositories_path: packages/apt/repositories/
           - label: CentOS 7
             id: centos-7

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -46,6 +46,8 @@ class GroongaNormalizerMySQLPackageTask < PackagesGroongaOrgPackageTask
 
   def apt_targets_default
     [
+      "debian-bullseye",
+      "debian-bullseye-arm64",
       "debian-buster",
       "debian-buster-i386",
     ]

--- a/packages/apt/debian-bullseye-arm64/from
+++ b/packages/apt/debian-bullseye-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/debian:bullseye

--- a/packages/apt/debian-bullseye/Dockerfile
+++ b/packages/apt/debian-bullseye/Dockerfile
@@ -1,0 +1,25 @@
+ARG FROM=debian:bullseye
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    wget && \
+  wget https://packages.groonga.org/debian/groonga-apt-source-latest-bullseye.deb && \
+  apt install -y -V ${quiet} ./groonga-apt-source-latest-bullseye.deb && \
+  rm ./groonga-apt-source-latest-bullseye.deb && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    pkg-config && \
+  apt clean


### PR DESCRIPTION
This PR has already passed CI at https://github.com/komainu8/groonga-normalizer-mysql/actions/runs/1461425849.