### PR TITLE
Fix to add an original char length to checks when a blank is removed

### DIFF
--- a/normalizers/mysql.c
+++ b/normalizers/mysql.c
@@ -408,7 +408,7 @@ normalize(grn_ctx *ctx, grn_obj *string,
         current_type[-1] |= GRN_CHAR_BLANK;
       }
       if (current_check) {
-        current_check[0]++;
+        current_check[0] += character_length;
       }
       normalized_length_in_bytes = previous_normalized_length_in_bytes;
       normalized_n_characters = previous_normalized_n_characters;

--- a/test/suite/unicode_ci/remove_blank_full_width.expected
+++ b/test/suite/unicode_ci/remove_blank_full_width.expected
@@ -1,4 +1,4 @@
 register normalizers/mysql
 [[0,0.0,0.0],true]
 normalize NormalizerMySQLUnicodeCI "　a　　b　　　c" REMOVE_BLANK|WITH_CHECKS
-[[0,0.0,0.0],{"normalized":"ABC","types":[],"checks":[2,3,4]}]
+[[0,0.0,0.0],{"normalized":"ABC","types":[],"checks":[4,7,10]}]


### PR DESCRIPTION
- Fix to add an original char length to `checks` when a blank is removed.
  - This bug causes https://github.com/groonga/groonga/issues/1280
