### PR TITLE
packages ubuntu: add support for Ubuntu 24.04 arm64

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,6 +31,7 @@ jobs:
           - debian-bookworm-amd64
           - debian-bookworm-arm64
           - ubuntu-noble-amd64
+          - ubuntu-noble-arm64
           - almalinux-8-x86_64
           - almalinux-8-aarch64
           - almalinux-9-x86_64

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -50,7 +50,7 @@ class GroongaNormalizerMySQLPackageTask < PackagesGroongaOrgPackageTask
       "debian-bookworm",
       "debian-bookworm-arm64",
       "ubuntu-noble",
-      "ubuntu-noble-arm64"
+      "ubuntu-noble-arm64",
     ]
   end
 

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -49,7 +49,8 @@ class GroongaNormalizerMySQLPackageTask < PackagesGroongaOrgPackageTask
     [
       "debian-bookworm",
       "debian-bookworm-arm64",
-      "ubuntu-noble"
+      "ubuntu-noble",
+      "ubuntu-noble-arm64"
     ]
   end
 

--- a/packages/apt/ubuntu-noble-arm64/from
+++ b/packages/apt/ubuntu-noble-arm64/from
@@ -1,0 +1,1 @@
+--platform=linux/arm64 arm64v8/ubuntu:noble


### PR DESCRIPTION
We will release groonga-normalizer-mysql package from packages.groonga.org.
This is the first step to add support for Ubuntu packages.