### PR TITLE
ci package: use ubuntu-24.04-arm64 for amr64 packages

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,7 +40,9 @@ jobs:
           # Groonga doesn't provide the package for
           # amazon-linux-2023-aarch64 yet.
           # - amazon-linux-2023-aarch64
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ contains(matrix.id, 'arm64') && 'ubuntu-24.04-arm' ||
+                                          'ubuntu-latest' }}
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     steps:


### PR DESCRIPTION
GitHub Actions support arm64 runners using ubuntu-24.04-arm64.
ref: https://github.blog/changelog/2024-06-24-github-actions-ubuntu-24-04-image-now-available-for-arm64-runners/