### PR TITLE
packages amazon linux 2023: add support for aarch64

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,9 +37,7 @@ jobs:
           - almalinux-9-x86_64
           - almalinux-9-aarch64
           - amazon-linux-2023-x86_64
-          # Groonga doesn't provide the package for
-          # amazon-linux-2023-aarch64 yet.
-          # - amazon-linux-2023-aarch64
+          - amazon-linux-2023-aarch64
     # condition && true-case || false-case
     # ==
     # condition ? true-case : false-case


### PR DESCRIPTION
Groonga has already provided the package for Amazon Linux 2023 aarch64.