### PR TITLE
packages ubuntu: add support for Ubuntu 22.04 (Jammy Jellyfish)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,8 @@ jobs:
         id:
           - debian-bookworm-amd64
           - debian-bookworm-arm64
+          - ubuntu-jammy-amd64
+          - ubuntu-jammy-arm64
           - ubuntu-noble-amd64
           - ubuntu-noble-arm64
           - almalinux-8-x86_64

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -49,6 +49,8 @@ class GroongaNormalizerMySQLPackageTask < PackagesGroongaOrgPackageTask
     [
       "debian-bookworm",
       "debian-bookworm-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
       "ubuntu-noble",
       "ubuntu-noble-arm64",
     ]

--- a/packages/apt/ubuntu-jammy-arm64/from
+++ b/packages/apt/ubuntu-jammy-arm64/from
@@ -1,0 +1,1 @@
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/apt/ubuntu-jammy/Dockerfile
+++ b/packages/apt/ubuntu-jammy/Dockerfile
@@ -1,0 +1,29 @@
+ARG FROM=ubuntu:jammy
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    ca-certificates \
+    lsb-release \
+    wget && \
+  wget https://packages.groonga.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    cmake \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    pkg-config && \
+  apt clean


### PR DESCRIPTION
We will release groonga-normalizer-mysql package from packages.groonga.org.
This is the one of steps to add support for Ubuntu packages by packages.groonga.org.