### PR TITLE
package: almalinux8: Add Apache Arrow repository install

### DIFF
--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -8,7 +8,8 @@ RUN \
   dnf install -y ${quiet} \
     epel-release \
     'dnf-command(config-manager)' \
-    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf config-manager --set-enabled powertools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -33,8 +33,6 @@ esac
 case ${os} in
   amazon-linux)
     DNF="dnf"
-    ${DNF} install -y \
-      https://apache.jfrog.io/artifactory/arrow/amazon-linux/${version}/apache-arrow-release-latest.rpm
     ;;
   *)
     case ${version} in
@@ -43,15 +41,14 @@ case ${os} in
         ;;
       *)
         DNF="dnf --enablerepo=crb"
-        ${DNF} install -y \
-          https://apache.jfrog.io/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
         ;;
     esac
     ;;
 esac
 
 ${DNF} install -y \
-  https://packages.groonga.org/${os}/${version}/groonga-release-latest.noarch.rpm
+  https://packages.groonga.org/${os}/${version}/groonga-release-latest.noarch.rpm \
+  https://packages.apache.org/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
 
 repositories_dir=/host/packages/yum/repositories
 ${DNF} install -y \


### PR DESCRIPTION
Related: https://github.com/groonga/groonga/pull/2292
Error in build because Groonga repository dropped serving arrow-devel-x.x.x.