### PR TITLE
fix macro redefinition error for GROONGA_NORMALIZER_MYSQL_EMBED

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -19,4 +19,6 @@
 
 #pragma once
 
+#ifndef GROONGA_NORMALIZER_MYSQL_EMBED
 #cmakedefine GROONGA_NORMALIZER_MYSQL_EMBED
+#endif


### PR DESCRIPTION
We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/storage/mroonga/groonga-normalizer-mysql/normalizers/../config.h:22:9: error: "GROONGA_NORMALIZER_MYSQL_EMBED" redefined [-Werror]
   22 | #define GROONGA_NORMALIZER_MYSQL_EMBED
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

So we added `#ifndef` guard around
GROONGA_NORMALIZER_MYSQL_EMBED to prevent redefinition conflicts when the macro is also defined via
command-line flags during compilation.