### PR TITLE
fix macro redefinition error for `GROONGA_NORMALIZER_MYSQL_EMBED`

### DIFF
--- a/normalizers/CMakeLists.txt
+++ b/normalizers/CMakeLists.txt
@@ -34,8 +34,6 @@ set(MYSQL_SOURCES
   mysql_unicode_1400_as_cs_table.h)
 if(GROONGA_NORMALIZER_MYSQL_EMBED)
   add_library(mysql_normalizer STATIC ${MYSQL_SOURCES})
-  set_property(TARGET mysql_normalizer APPEND PROPERTY
-    COMPILE_DEFINITIONS "GROONGA_NORMALIZER_MYSQL_EMBED")
   set_target_properties(
     mysql_normalizer
     PROPERTIES


### PR DESCRIPTION
## Issue

We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/storage/mroonga/groonga-normalizer-mysql/normalizers/../config.h:22:9: error: "GROONGA_NORMALIZER_MYSQL_EMBED" redefined [-Werror]
   22 | #define GROONGA_NORMALIZER_MYSQL_EMBED
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

## Cause

When building Groonga with MariaDB, the macro
`GROONGA_NORMALIZER_MYSQL_EMBED` was defined
twice by Mroonga’s CMake configuration and again in normalizers/CMakeLists.txt via `COMPILE_DEFINITIONS`, which triggeres a redefinition error.

## Solution

Remove the redundant `COMPILE_DEFINITIONS` so that the macro is only defined once.