### PR TITLE
ci arch-linux: use bundled Blosc2 instead of system

### DIFF
--- a/ci/arch-linux/PKGBUILD
+++ b/ci/arch-linux/PKGBUILD
@@ -40,6 +40,16 @@ build() {
     -D CMAKE_BUILD_TYPE=None
     -D CMAKE_INSTALL_PREFIX=/usr
     -D CMAKE_SKIP_RPATH=ON
+    # This is a workaround.
+    # Currently, the system-provided Blosc2 is not used when building Groonga due to the following error.
+    #
+    # CMake Error at /usr/lib/cmake/Blosc2/Blosc2Targets.cmake:108 (message):
+    # The imported target "Blosc2::blosc2_static" references the file
+    # "/usr/lib/libblosc2.a"
+    #
+    # This is an upstream issue.
+    # So, we use bundled Blosc2 until the upstream issue is resolved.
+    -D GRN_WITH_BLOSC=bundled
   )
   cmake "${cmake_options[@]}"
   cmake --build build


### PR DESCRIPTION
TODO: Test on CI.

Currently, the system-provided Blosc2 is not use when Groonga is built due to the following error.

```
CMake Error at /usr/lib/cmake/Blosc2/Blosc2Targets.cmake:108 (message):
The imported target "Blosc2::blosc2_static" references the file
"/usr/lib/libblosc2.a"
```

This is an upstream issue.
So, we use bundled Blosc2 until the upstream issue is resolved.